### PR TITLE
Replace the ISO-639-3 code "blu" by "hmn" (Hmong language)

### DIFF
--- a/src/main/java/org/commoncrawl/langdetect/cld2/Language.java
+++ b/src/main/java/org/commoncrawl/langdetect/cld2/Language.java
@@ -203,7 +203,7 @@ public enum Language {
   CEBUANO               ("ceb", 165),  // ceb
   EWE                   ("ewe", 166),  // ee
   GA                    ("gaa", 167),  // gaa
-  HMONG                 ("blu", 168),  // blu  = [hmv,mww,...]
+  HMONG                 ("hmn", 168),  // hmn - used to be "blu" (see https://iso639-3.sil.org/code/blu)
   KRIO                  ("kri", 169),  // kri
   LOZI                  ("loz", 170),  // loz
   LUBA_LULUA            ("lua", 171),  // lua


### PR DESCRIPTION
- "blu" is deprecated since 2008, see https://iso639-3.sil.org/code/blu
- mapping was already fixed in [CLD2](/CLD2Owners/cld2) (CLD2Owners/cld2@9d8940c)
- but not transferred into Language.java